### PR TITLE
内部の細かな修正と改善

### DIFF
--- a/fzpac
+++ b/fzpac
@@ -69,6 +69,10 @@ _version() {
 	echo "$THIS_CMD -- Version $VERSION"
 }
 
+_fzf(){
+	env LANG=C fzf "${@}"
+}
+
 _main() {
 	if [[ $# -lt 1 ]]; then
 		_help
@@ -154,21 +158,21 @@ _select_available_pkgs() {
 	pacman_cmd="$1"
 	shift
 	"${pacman_cmd}" -Ssq "${@}" |
-		fzf --multi --preview "${pacman_cmd} -Si {}"
+		_fzf --multi --preview "${pacman_cmd} -Si {}"
 }
 
 _select_local_pkgs() {
 	pacman_cmd="$1"
 	shift
 	"${pacman_cmd}" -Qsq "${@}" |
-		fzf --multi --preview "${pacman_cmd} -Qil {}"
+		_fzf --multi --preview "${pacman_cmd} -Qil {}"
 }
 
 _view_available_pkgs() {
 	pacman_cmd="$1"
 	shift
 	"${pacman_cmd}" -Ssq "${@}" |
-		fzf --preview "${pacman_cmd} -Si {}" \
+		_fzf --preview "${pacman_cmd} -Si {}" \
 			--bind "enter:execute(${pacman_cmd} -Sii {} | less)"
 }
 
@@ -176,9 +180,9 @@ _view_local_pkgs() {
 	pacman_cmd="$1"
 	shift
 	"${pacman_cmd}" -Qsq "${@}" |
-		fzf --preview "${pacman_cmd} -Qil {}" \
+		_fzf --preview "${pacman_cmd} -Qil {}" \
 			--bind "enter:execute(${pacman_cmd} -Qil {} | less)"
 }
 
 _main "${@}"
-exit ${?}
+exit "${?}"

--- a/fzpac
+++ b/fzpac
@@ -3,6 +3,12 @@
 readonly THIS_CMD="${0##*/}"
 readonly VERSION='1.1.0'
 
+readonly PACMANS=(
+	"paru"
+	"yay"
+	"pacman"
+)
+
 _help() {
 	cat <<EOF
 $THIS_CMD -- Arch Linux package finder with fzf
@@ -48,16 +54,15 @@ _test_fzf() {
 }
 
 _get_pacman_cmd() {
-	if command -v paru &>/dev/null; then
-		echo paru
-	elif command -v yay &>/dev/null; then
-		echo yay
-	elif command -v pacman &>/dev/null; then
-		echo pacman
-	else
-		_err 'The command for pacman or AUR helper was not found.'
-		exit 1
-	fi
+	local _cmd
+	for _cmd in "${PACMANS[@]}"; do
+		if command -v "${_cmd}" &>/dev/null; then
+			echo -n "${_cmd}"
+			return 0
+		fi
+	done
+	_err 'The command for pacman or AUR helper was not found.'
+	exit 1
 }
 
 _version() {

--- a/fzpac
+++ b/fzpac
@@ -79,53 +79,53 @@ _main() {
 
 	pacman_cmd="$(_get_pacman_cmd)"
 
-	for arg in "$@"; do
+	for arg in "${@}"; do
 		case "$arg" in
 		s | select)
 			shift
-			_select_available_pkgs "$pacman_cmd" "$@"
+			_select_available_pkgs "${pacman_cmd}" "${@}"
 			break
 			;;
 		q | select-local)
 			shift
-			_select_local_pkgs "$pacman_cmd" "$@"
+			_select_local_pkgs "${pacman_cmd}" "${@}"
 			break
 			;;
 		i | info)
 			shift
-			_select_available_pkgs "$pacman_cmd" "$@" | "$pacman_cmd" -Sii -
+			_select_available_pkgs "${pacman_cmd}" "${@}" | "${pacman_cmd}" -Sii -
 			break
 			;;
 		l | info-local)
 			shift
-			_select_local_pkgs "$pacman_cmd" "$@" | "$pacman_cmd" -Qii -
+			_select_local_pkgs "${pacman_cmd}" "${@}" | "${pacman_cmd}" -Qii -
 			break
 			;;
 		p | view)
 			shift
-			_view_available_pkgs "$pacman_cmd" "$@"
+			_view_available_pkgs "${pacman_cmd}" "${@}"
 			break
 			;;
 		v | view-local)
 			shift
-			_view_local_pkgs "$pacman_cmd" "$@"
+			_view_local_pkgs "${pacman_cmd}" "${@}"
 			break
 			;;
 		S | install)
 			shift
-			if [ "$pacman_cmd" = 'pacman' ]; then
-				_select_available_pkgs pacman "$@" | sudo pacman -S -
+			if [ "${pacman_cmd}" = 'pacman' ]; then
+				_select_available_pkgs pacman "${@}" | sudo pacman -S -
 			else
-				_select_available_pkgs "$pacman_cmd" "$@" | "$pacman_cmd" -S -
+				_select_available_pkgs "${pacman_cmd}" "${@}" | "${pacman_cmd}" -S -
 			fi
 			break
 			;;
 		R | remove)
 			shift
-			if [ "$pacman_cmd" = 'pacman' ]; then
-				_select_local_pkgs pacman "$@" | sudo pacman -Rn -
+			if [ "${pacman_cmd}" = 'pacman' ]; then
+				_select_local_pkgs pacman "${@}" | sudo pacman -Rn -
 			else
-				_select_local_pkgs "$pacman_cmd" "$@" | "$pacman_cmd" -Rn -
+				_select_local_pkgs "${pacman_cmd}" "${@}" | "${pacman_cmd}" -Rn -
 			fi
 			break
 			;;
@@ -147,38 +147,38 @@ _main() {
 }
 
 _err() {
-	echo -e "[ \e[31mERR\e[m ] $*" >&2
+	echo -e "[ \e[31mERR\e[m ] ${*}" >&2
 }
 
 _select_available_pkgs() {
 	pacman_cmd="$1"
 	shift
-	"$pacman_cmd" -Ssq "$@" |
-		fzf --multi --preview "$pacman_cmd -Si {}"
+	"${pacman_cmd}" -Ssq "${@}" |
+		fzf --multi --preview "${pacman_cmd} -Si {}"
 }
 
 _select_local_pkgs() {
 	pacman_cmd="$1"
 	shift
-	"$pacman_cmd" -Qsq "$@" |
-		fzf --multi --preview "$pacman_cmd -Qil {}"
+	"${pacman_cmd}" -Qsq "${@}" |
+		fzf --multi --preview "${pacman_cmd} -Qil {}"
 }
 
 _view_available_pkgs() {
 	pacman_cmd="$1"
 	shift
-	"$pacman_cmd" -Ssq "$@" |
-		fzf --preview "$pacman_cmd -Si {}" \
-			--bind "enter:execute($pacman_cmd -Sii {} | less)"
+	"${pacman_cmd}" -Ssq "${@}" |
+		fzf --preview "${pacman_cmd} -Si {}" \
+			--bind "enter:execute(${pacman_cmd} -Sii {} | less)"
 }
 
 _view_local_pkgs() {
 	pacman_cmd="$1"
 	shift
-	"$pacman_cmd" -Qsq "$@" |
-		fzf --preview "$pacman_cmd -Qil {}" \
-			--bind "enter:execute($pacman_cmd -Qil {} | less)"
+	"${pacman_cmd}" -Qsq "${@}" |
+		fzf --preview "${pacman_cmd} -Qil {}" \
+			--bind "enter:execute(${pacman_cmd} -Qil {} | less)"
 }
 
-_main "$@"
-exit $?
+_main "${@}"
+exit ${?}

--- a/fzpac
+++ b/fzpac
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 readonly THIS_CMD="${0##*/}"
 readonly VERSION='1.1.0'


### PR DESCRIPTION
- [update] 容易に拡張できるpacmanコマンド一覧 66fe1ab
対応しているコマンドを配列にすることで将来的な拡張を容易にします

- [fix] 変数を { }で囲う 4571162
[Googleによると](https://google.github.io/styleguide/shellguide.html#s5.6-variable-expansion)変数名は[{}]で囲うことが推奨されています

- [fix] シェバンにenvを使う 69488b3
`#!/bin/bash`ではなく`#!/usr/bin/env bash`を使うことでスクリプトの柔軟性が向上します

- [fix] 常にfzf内で英語を使う 8ba2806
fzfコマンドを日本語などの特殊な文字で実行するとレイアウトが崩れてしまいます
そのため`LANG=C`を指定して強制的に英語を使用します
（英語以外のアルファベットしか使わない言語の場合でも英語にしてしまうため注意が必要です）

![image](https://user-images.githubusercontent.com/32128205/116784087-350d1700-aacd-11eb-8e3c-000babeb58ec.png)


