### PR TITLE
サブコマンドのタブ補完を可能にするBash用のcompletionsファイルを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+FZPAC_SRC_PATH := fzpac
+FZPAC_DEST_PATH := /usr/local/bin/fzpac
+BASH_COMPLETION_SRC_PATH := completions/bash/fzpac
+BASH_COMPLETION_DEST_PATH := /usr/share/bash-completion/completions/fzpac
+
+.PHONY: install
+install:
+	sudo install -o root -g root -m 0755 $(FZPAC_SRC_PATH) $(FZPAC_DEST_PATH)
+	sudo install -o root -g root -m 0644 $(BASH_COMPLETION_SRC_PATH) $(BASH_COMPLETION_DEST_PATH)
+
+.PHONY: uninstall
+uninstall:
+	sudo rm -f $(FZPAC_DEST_PATH)
+	sudo rm -f $(BASH_COMPLETION_DEST_PATH)
+
+.PHONY: format
+format:
+	shfmt -w $(FZPAC_SRC_PATH)
+	shfmt -w $(BASH_COMPLETION_SRC_PATH)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ You can quickly find a package to browse its detailed information and install / 
 
 <image src="./img/screenshot.png" width="70%">
 
-
 ## Usage
 
 When you run the command, the preview pane displays detailed package information and a list of files.
@@ -49,7 +48,6 @@ SUBCMD
     V, version       Show version.
 ```
 
-
 ## Installation
 
 ### Dependence
@@ -85,3 +83,21 @@ wget https://raw.githubusercontent.com/sheepla/fzpac/main/fzpac && chmod +x fzpa
 curl -O https://raw.githubusercontent.com/sheepla/fzpac/main/fzpac && chmod +x fzpac
 ```
 
+#### Use `bash-completion`
+
+Run below if you want to use `bash-completion` for `fzpac`.
+
+```bash
+wget -O fzpac https://raw.githubusercontent.com/sheepla/fzpac/main/completions/bash/fzpac && sudo install -o root -g root -m 0644 fzpac /usr/share/bash-completion/completions/fzpac
+# or curl
+```
+
+#### Install `fzpac` and `bash-completion`
+
+Run below if you want to install `fzpac` and `bash-completion` for `fzpac`.
+
+```bash
+git clone https://github.com/sheepla/fzpac
+cd fzpac
+make install
+```

--- a/completions/bash/fzpac
+++ b/completions/bash/fzpac
@@ -1,0 +1,13 @@
+# fzpac(1) completion                                       -*- shell-script -*-
+
+_fzpac_module() {
+	local cur prev cword
+	_get_comp_words_by_ref -n : cur prev cword
+
+	if [[ "${cword}" -eq 1 ]]; then
+		local subcmds="search select-local info info-local view-local install remove help version"
+		COMPREPLY=($(compgen -W "${subcmds}" -- "${cur}"))
+	fi
+}
+
+complete -F _fzpac_module fzpac


### PR DESCRIPTION
- サブコマンドを途中まで入力した状態でTABを押すと選択候補を補完してくれる `bash-completion` 用の completions ファイルを追加
- fzpac と completions ファイルをまとめてインストール、アンインストールするためのMakefileを追加
- completions ファイルをインストールするための手順をREADMEに追記
