### PR TITLE
CIでコードフォーマットチェックと静的解析を行うように変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'LICENSE'
+      - 'README.*'
+  pull_request:
+    paths-ignore:
+      - 'LICENSE'
+      - 'README.*'
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install formatter
+        run: make setup_tools
+      - name: Format
+        run: make check_format_on_docker
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install formatter
+        run: make setup_tools
+      - name: Format
+        run: make lint_on_docker

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,12 @@ README_DEST_PATH := $(SHAREDIR)/doc/$(NAME)/README.md
 DOCKER_TOOL_IMAGE := tools
 DOCKER_LINT_CMD := docker run --rm -v $$PWD:/work -w /work $(DOCKER_TOOL_IMAGE)
 
+.PHONY: help
+help: ## Print help documents
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
 .PHONY: echo
-echo:
+echo: ## Print source paths and destination paths
 	echo FZPAC_SRC_PATH: $(FZPAC_SRC_PATH)
 	echo FZPAC_DEST_PATH: $(FZPAC_DEST_PATH)
 	echo BASH_COMPLETION_SRC_PATH: $(BASH_COMPLETION_SRC_PATH)
@@ -41,7 +45,7 @@ echo:
 	echo LICENSE_DEST_PATH: $(LICENSE_DEST_PATH)
 
 .PHONY: install
-install:
+install: ## Install programs
 	install -Dm 0755 $(FZPAC_SRC_PATH) $(FZPAC_DEST_PATH)
 	install -Dm 0644 $(BASH_COMPLETION_SRC_PATH) $(BASH_COMPLETION_DEST_PATH)
 	install -Dm 0644 $(FISH_COMPLETION_SRC_PATH) $(FISH_COMPLETION_DEST_PATH)
@@ -50,7 +54,7 @@ install:
 	install -Dm 0644 $(LICENSE_SRC_PATH) $(LICENSE_DEST_PATH)
 
 .PHONY: uninstall
-uninstall:
+uninstall: ## Uninstall programs
 	rm -f $(FZPAC_DEST_PATH)
 	rm -f $(BASH_COMPLETION_DEST_PATH)
 	rm -f $(FISH_COMPLETION_DEST_PATH)
@@ -59,26 +63,26 @@ uninstall:
 	rm -f $(LICENSE_DEST_PATH)
 
 .PHONY: format
-format:
+format: ## Format code and write a file
 	shfmt -w $(FZPAC_SRC_PATH)
 	#shfmt -w $(BASH_COMPLETION_SRC_PATH)
 	#shfmt -w $(FISH_COMPLETION_SRC_PATH)
 	#shfmt -w $(ZSH_COMPLETION_SRC_PATH)
 
 .PHONY: lint
-lint:
+lint: ## Lint code
 	shellcheck $(FZPAC_SRC_PATH)
 	#shellcheck $(BASH_COMPLETION_SRC_PATH)
 	#shellcheck $(ZSH_COMPLETION_SRC_PATH)
 
 .PHONY: setup_tools
-setup_tools:
+setup_tools: ## Setup linter tools
 	docker build -t $(DOCKER_TOOL_IMAGE) tools/linter
 
 .PHONY: check_format_on_docker
-check_format_on_docker:
+check_format_on_docker: ## Check format code on docker
 	$(DOCKER_LINT_CMD) shfmt -d $(FZPAC_SRC_PATH)
 
 .PHONY: lint_on_docker
-lint_on_docker:
+lint_on_docker: ## Lint code on docker
 	$(DOCKER_LINT_CMD) shellcheck $(FZPAC_SRC_PATH)

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ LICENSE_DEST_PATH := $(SHAREDIR)/licenses/$(NAME)/LICENSE
 README_SRC_PATH := README.md
 README_DEST_PATH := $(SHAREDIR)/doc/$(NAME)/README.md
 
+DOCKER_TOOL_IMAGE := tools
+DOCKER_LINT_CMD := docker run --rm -v $$PWD:/work -w /work $(DOCKER_TOOL_IMAGE)
+
 .PHONY: echo
 echo:
 	echo FZPAC_SRC_PATH: $(FZPAC_SRC_PATH)
@@ -67,3 +70,15 @@ lint:
 	shellcheck $(FZPAC_SRC_PATH)
 	#shellcheck $(BASH_COMPLETION_SRC_PATH)
 	#shellcheck $(ZSH_COMPLETION_SRC_PATH)
+
+.PHONY: setup_tools
+setup_tools:
+	docker build -t $(DOCKER_TOOL_IMAGE) tools/linter
+
+.PHONY: check_format_on_docker
+check_format_on_docker:
+	$(DOCKER_LINT_CMD) shfmt -d $(FZPAC_SRC_PATH)
+
+.PHONY: lint_on_docker
+lint_on_docker:
+	$(DOCKER_LINT_CMD) shellcheck $(FZPAC_SRC_PATH)

--- a/tools/linter/Dockerfile
+++ b/tools/linter/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.14
+
+ARG SHFMT_VERSION="v3.3.1"
+ARG SHELLCHECK_VERSION="v0.7.2"
+
+WORKDIR /tmp
+RUN apk add --no-cache wget && \
+    wget -O /usr/local/bin/shfmt https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_amd64 && \
+    chmod +x /usr/local/bin/shfmt && \
+    wget https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz && \
+    tar xf shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz && \
+    install -m 0755 shellcheck-${SHELLCHECK_VERSION}/shellcheck /usr/local/bin/shellcheck


### PR DESCRIPTION
## 変更内容

- CIに `make format` と同じ操作を行う処理を追加
- CIに `make lint` と同じ操作を行う処理を追加
- CI環境用のツールを用意するためのDockerfileを追加
- Makefileにかかれているタスクのヘルプを出力する `make help` を追加

## 動作

- [Lintに引っかかるパターン](https://github.com/jiro4989/fzpac/runs/3453550367?check_suite_focus=true)
- [パスするパターン](https://github.com/jiro4989/fzpac/actions/runs/1178720045)