### PR TITLE
Add another fuzzy finders support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <div align="center">
     
-`fzpac` is a `pacman` wrapper, an Arch Linux package finder with `fzf`.
+`fzpac` is a `pacman` wrapper, an Arch Linux package finder with `fuzzy finder`.
 
 </div>
 
@@ -38,13 +38,13 @@ curl -LO git.io/fzpac && chmod +x fzpac
 ## Usage
 
 1. Run this command
-2. Select the packages with `fzf`
+2. Select the packages with `fuzzy finder`
 3. You can view the package info or install / uninstall it immediately
 
 ### Help Message
 
 ```
-fzpac -- Arch Linux package finder with fzf
+fzpac -- Arch Linux package finder with fuzzy finder
 
 USAGE
     fzpac SUBCMD [KEYWORDS...]
@@ -75,15 +75,22 @@ KEY BINDINGS
 
 ### Dependence
 
-Requires `fzf`.
+Requires `fzf`, `sk` or your favorite fuzzy finder, but recommended one is `fzf` or `sk` to use full features.
 
 <a href="https://github.com/junegunn/fzf">junegunn/fzf</a>
+<a href="https://https://github.com/lotabout/skim">lotabout/skim</a>
 
-If `fzf` is not installed, install it with the following command:
+If `fzf` or `sk` is not installed, install it with the following command:
 
 ```bash
 sudo pacman -S fzf
+
+# or
+
+sudo pacman -S sk
 ```
+
+If you want to use other fuzzy finder, see 'FZPAC_FINDER' section in Configuration.
 
 ### Optional
 
@@ -163,7 +170,9 @@ cd fzpac
 sudo make install
 ```
 
-## Configuration
+## Configurations
+
+### FZPAC_PACMAN
 
 To change the AUR helper command to use, run fzpac with the value of the `"${FZPAC_PACMAN}"` variable set.
 
@@ -175,6 +184,22 @@ To always use this setting, add the following line to your `~/.bashrc` or other 
 
 ```bash
 export FZPAC_PACMAN="some-aur-helper-command"
+```
+
+### FZPAC_FINDER
+
+To change the fuzzy finder which is used in fzpac, set the `"${FZPAC_FINDER}"` variable.
+
+This value is colon separated list like a `"${PATH}"` variable, elements are but commands not directories. fzpac trys to use each of commands in `"${FZPAC_FINDER}"` in turn as fuzzy finder to find packages. So fallback to following commands if preceding one isn't found.
+
+If no `"${FZPAC_FINDER}"` is set or empty, fzpac assumes the value is 'fzf:sk:peco:gof:fzy'.
+
+```bash
+# Elements are command name or path.
+FZPAC_FINDER="finder1:/path/to/finder2:..." fzpac ...
+
+# Precede your favorite fuzzy finder if you want to give priority to it.
+FZPAC_FINDER="sk:fzf:..." fzpac ...
 ```
 
 ## Contribution

--- a/fzpac
+++ b/fzpac
@@ -13,6 +13,7 @@ readonly PACMAN_LIST=(
 	"yay"
 	"pacman"
 )
+readonly FZPAC_FINDER="${FZPAC_FINDER:-fzf:sk:peco:gof:fzy}"
 readonly STYLE_BOLD=$'\033[1m'
 readonly STYLE_UNDERBAR=$'\033[4m'
 readonly STYLE_RESET=$'\033[m'
@@ -37,7 +38,7 @@ EOF
 
 _help() {
 	cat <<EOF
-${THIS_CMD} -- Arch Linux package finder with fzf
+${THIS_CMD} -- Arch Linux package finder with fuzzy finder
 
 ${STYLE_BOLD}USAGE${STYLE_RESET}
     ${THIS_CMD} ${STYLE_UNDERBAR}SUBCMD${STYLE_RESET} [${STYLE_UNDERBAR}KEYWORDS...${STYLE_RESET}]
@@ -73,7 +74,8 @@ _main() {
 		exit 1
 	fi
 
-	_test_cmd fzf || return 1
+	local finder
+	finder="$(_finder)"
 
 	local pac
 	pac="$(_pacman)"
@@ -82,19 +84,19 @@ _main() {
 		case "${arg}" in
 		s | search)
 			shift
-			_search "${pac}" "${@}"
+			_search "${pac}" "${finder}" "${@}"
 			break
 			;;
 		l | local)
 			shift
-			_search_local "${pac}" "${@}"
+			_search_local "${pac}" "${finder}" "${@}"
 			break
 			;;
 		S | install)
 			shift
 			local pkgs
 			pkgs=(
-				"$(_search "${pac}" "${@}")"
+				"$(_search "${pac}" "${finder}" "${@}")"
 			)
 			_install "${pac}" "${pkgs[@]}"
 			break
@@ -103,7 +105,7 @@ _main() {
 			shift
 			local pkgs
 			pkgs=(
-				"$(_search_local "${pac}" "${@}")"
+				"$(_search_local "${pac}" "${finder}" "${@}")"
 			)
 			_remove "${pac}" "${pkgs[@]}"
 			break
@@ -112,7 +114,7 @@ _main() {
 			shift
 			local pkgs
 			pkgs=(
-				"$(_search_no_deps "${pac}" "${@}")"
+				"$(_search_no_deps "${pac}" "${finder}" "${@}")"
 			)
 			_remove "${pac}" "${pkgs[@]}"
 			break
@@ -134,13 +136,8 @@ _main() {
 	done
 }
 
-_test_cmd() {
-	for cmd in "${@}"; do
-		if ! command -v "${cmd}" &>/dev/null; then
-			_err "${cmd} is not installed. please install it."
-			return 1
-		fi
-	done
+_has() {
+	command -v "${1}" &>/dev/null
 }
 
 _pacman() {
@@ -160,8 +157,72 @@ _pacman() {
 	exit 1
 }
 
-_fzf() {
-	env LANG=C fzf "${@}"
+# 'Fuzzy finder' finder. Exit process if no fuzzy finder is found.
+_finder() {
+	for f in ${FZPAC_FINDER/:/ }; do
+		if _has "${f}"; then
+			echo "${f}"
+			return 0
+		fi
+	done
+
+	if [[ "${FZPAC_FINDER}" == *:* ]]; then
+		_err "${FZPAC_FINDER/:/, } aren't found."
+	else
+		_err "${FZPAC_FINDER} isn't found."
+	fi
+
+	exit 1
+}
+
+# A simple abstraction between multiple fuzzy finders. This takes fuzzy finder
+# and the options as arguments, then select only supported them by the finder
+# and run the finder with selected options.
+#
+# Arguments
+#   1: Fuzzy finder name or path
+#   2-: Options for fuzzy finder
+#
+# Any options which aren't below are not supported and ignored.
+#
+# Supported options for fzf and sk:
+# - --multi
+# - --header STR
+# - --preview COMMAND
+# - --bind KEYBINDS
+_fuzzyfinder() {
+	local -r finder="${1}"
+	shift
+
+	local -a args=()
+
+	if [[ "${finder}" =~ (fzf|sk) ]]; then
+		while (($#)); do
+			case "${1}" in
+			-m | --multi)
+				args+=(--multi)
+				shift
+				;;
+			--header)
+				args+=(--header "${2}")
+				shift 2
+				;;
+			--preview)
+				args+=(--preview "${2}")
+				shift 2
+				;;
+			--bind)
+				args+=(--bind "${2}")
+				shift 2
+				;;
+			*)
+				shift
+				;;
+			esac
+		done
+	fi
+
+	env LANG=C "${finder}" "${args[@]}"
 }
 
 _err() {
@@ -172,12 +233,14 @@ _search() {
 	readonly HEADER="<C-s>: show package info"
 
 	local pac="${1}"
-	shift
+	local finder="${2}"
+	shift 2
 
 	export -f _show_info
 
 	"${pac}" --sync --search --quiet "${@}" |
-		_fzf \
+		_fuzzyfinder \
+			"${finder}" \
 			--multi \
 			--header "${HEADER}" \
 			--preview "_show_info ${pac} {}" \
@@ -188,12 +251,14 @@ _search_local() {
 	readonly HEADER="<C-s>: show package info"
 
 	local pac="${1}"
-	shift
+	local finder="${2}"
+	shift 2
 
 	export -f _show_info_local
 
 	"${pac}" --query --search --quiet "${@}" |
-		_fzf \
+		_fuzzyfinder \
+			"${finder}" \
 			--multi \
 			--header "${HEADER}" \
 			--preview "_show_info_local ${pac} {}" \
@@ -204,12 +269,14 @@ _search_no_deps() {
 	readonly HEADER="<C-s>: show package info"
 
 	local pac="${1}"
-	shift
+	local finder="${2}"
+	shift 2
 
 	export -f _show_info_local
 
 	"${pac}" --query --deps --unrequired --quiet "${@}" |
-		_fzf \
+		_fuzzyfinder \
+			"${finder}" \
 			--multi \
 			--header "${HEADER}" \
 			--preview "_show_info_local ${pac} {}" \


### PR DESCRIPTION
Fixes #10

Different points from it is below.

`"${FZPAC_FINDER}"`'s value is colon separated list like a `"${PATH}"` variable, elements are but commands not directories. fzpac trys to use each of commands in `"${FZPAC_FINDER}"` in turn as fuzzy finder to find packages. So fallback to following commands if preceding one isn't found.

If no `"${FZPAC_FINDER}"` is set or empty, fzpac assumes the value is 'fzf:sk:peco:gof:fzy'.

```bash
# Elements are command name or path.
FZPAC_FINDER="finder1:/path/to/finder2:..." fzpac ...

# Precede your favorite fuzzy finder if you want to give priority to it.
FZPAC_FINDER="sk:fzf:..." fzpac ...
```