### PR TITLE
[fix] uppercase short install argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ USAGE
 SUBCMD
     s, search        search for all available packages
     l, local         search for already installed packages
-    s, install       select packages and INSTALL it
+    S, install       select packages and INSTALL it
     R, remove        select packages and UNINSTALL it
     A, autoremove    select packages that are no longer needed and UNINSTALL it.
     h, help          show help message

--- a/completions/fish/fzpac.fish
+++ b/completions/fish/fzpac.fish
@@ -3,7 +3,7 @@ complete -c fzpac -x
 complete -c fzpac -n '__fish_use_subcommand' -x -a 's select' -d 'search for all available packages'
 complete -c fzpac -n '__fish_use_subcommand' -x -a 's search' -d 'search for all available packages'
 complete -c fzpac -n '__fish_use_subcommand' -x -a 'l local' -d 'search for already installed packages'
-complete -c fzpac -n '__fish_use_subcommand' -x -a 's install' -d 'select packages and INSTALL it'
+complete -c fzpac -n '__fish_use_subcommand' -x -a 'S install' -d 'select packages and INSTALL it'
 complete -c fzpac -n '__fish_use_subcommand' -x -a 'R remove' -d 'select packages and UNINSTALL it'
 complete -c fzpac -n '__fish_use_subcommand' -x -a 'A autoremove' -d 'select packages that are no longer needed and UNINSTALL it'
 complete -c fzpac -n '__fish_use_subcommand' -x -a 'h help' -d 'show help message'

--- a/completions/zsh/_fzpac
+++ b/completions/zsh/_fzpac
@@ -5,7 +5,7 @@ _fzpac() {
 		"sub-commands" \
 		{s,search}"[search for all available packages]" \
 		{l,local}"[search for already installed packages]" \
-		{s,install}"[select packages and INSTALL it]" \
+		{S,install}"[select packages and INSTALL it]" \
 		{R,remove}"[select packages and UNINSTALL it]" \
 		{A,autoremove}"[select packages that are no longer needed and UNINSTALL it]" \
 		{h,help}"[show help message]" \

--- a/fzpac
+++ b/fzpac
@@ -48,7 +48,7 @@ ${STYLE_BOLD}USAGE${STYLE_RESET}
 ${STYLE_BOLD}SUBCMD${STYLE_RESET}
     s, search        search for all available packages
     l, local         search for already installed packages
-    s, install       select packages and INSTALL it
+    S, install       select packages and INSTALL it
     R, remove        select packages and UNINSTALL it
     A, autoremove    select packages that are no longer needed and UNINSTALL it
     h, help          show help message


### PR DESCRIPTION
The short version of the `install` (`S`) argument was lower cased in the doc and completion.