### PR TITLE
Use builtins instead of external commands

### DIFF
--- a/fzpac
+++ b/fzpac
@@ -216,7 +216,7 @@ _fuzzyfinder() {
 		done
 	fi
 
-	env LANG=C "${finder}" "${args[@]}"
+	LANG=C "${finder}" "${args[@]}"
 }
 
 _err() {
@@ -282,9 +282,9 @@ _show_info() {
 	local pkg="${2}"
 	shift 1
 
-	env LANG=C "${pac}" --sync --search --color=always "^${pkg}$"
+	LANG=C "${pac}" --sync --search --color=always "^${pkg}$"
 	echo ""
-	env LANG=C "${pac}" --sync --info --color=always "${pkg}"
+	LANG=C "${pac}" --sync --info --color=always "${pkg}"
 }
 
 _show_info_local() {
@@ -292,9 +292,9 @@ _show_info_local() {
 	local pkg="${2}"
 	shift 1
 
-	env LANG=C "${pac}" --query --search --color=always "^${pkg}$"
+	LANG=C "${pac}" --query --search --color=always "^${pkg}$"
 	echo ""
-	env LANG=C "${pac}" --query --info --list --color=always "${pkg}"
+	LANG=C "${pac}" --query --info --list --color=always "${pkg}"
 }
 
 _install() {

--- a/fzpac
+++ b/fzpac
@@ -3,7 +3,7 @@
 set -o errexit
 set -o nounset
 
-SHELL="$(which bash)"
+SHELL="$(type -P bash)"
 readonly SHELL
 
 readonly THIS_CMD="${0##*/}"

--- a/fzpac
+++ b/fzpac
@@ -19,7 +19,7 @@ _version() {
 	readonly LICENSE="MIT"
 	readonly GITHUB_URL="https://github.com"
 
-	cat <<EOF
+	echo -n -e "\
 
 ${STYLE_BOLD}${THIS_CMD}${STYLE_RESET} -- ${STYLE_UNDERBAR}v${VERSION}${STYLE_RESET}
 
@@ -28,11 +28,11 @@ Released under the ${LICENSE} License.
     Author: ${AUTHOR} (${GITHUB_URL}/${AUTHOR})
 
 * ${THIS_CMD} uses this command as a pacman-like command: $(_pacman)
-EOF
+"
 }
 
 _help() {
-	cat <<EOF
+	echo -n -e "\
 ${THIS_CMD} -- Arch Linux package finder with fuzzy finder
 
 ${STYLE_BOLD}USAGE${STYLE_RESET}
@@ -59,7 +59,7 @@ ${STYLE_BOLD}KEY BINDINGS${STYLE_RESET}
     ${STYLE_UNDERBAR}<C-s>${STYLE_RESET}         show information of the package
     ${STYLE_UNDERBAR}<Tab>${STYLE_RESET}         select a package
     ${STYLE_UNDERBAR}<CR>${STYLE_RESET}          confirm selection
-EOF
+"
 }
 
 _main() {


### PR DESCRIPTION
Remove extra dependencies(cat, env, which), but maybe these are installed in almost all environments...

This makes a little bit fast this command invocation because no external command loads.